### PR TITLE
Fix bug with passing wrong args to __init__ in Blob.__setstate__.

### DIFF
--- a/decaf/_blob.py
+++ b/decaf/_blob.py
@@ -145,7 +145,7 @@ class Blob(object):
     def __setstate__(self, state):
         """Recovers the state."""
         if state[0] is None:
-            Blob.__init__(self, state[1])
+            Blob.__init__(self, filler=state[1])
         else:
             Blob.__init__(self, state[0].shape, state[0].dtype, state[1])
             self._data[:] = state[0]


### PR DESCRIPTION
`__getstate__` returns `self.data(), self._filler`, where `self.data()` may be `None`.  But when `__setstate__` initializes the `Blob` and `state[0]` is `None`, it will wrongly pass the filler (`state[1]`) as the second positional argument to `__init__`.  But that is `dtype`, not `filler`.  Using a keyword argument fixes this.
