### PR TITLE
fixed compilation for OS X

### DIFF
--- a/decaf/layers/cpp/neuron.cpp
+++ b/decaf/layers/cpp/neuron.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdlib>
 #include "neuron.h"
 
 using std::max;


### PR DESCRIPTION
This is needed to compile on OS X. It defines EXIT_FAILURE.
