### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/decaf/Makefile
+++ b/decaf/Makefile
@@ -4,3 +4,5 @@ all_mkl:
 	make -C layers/cpp/ all_mkl
 test:
 	nosetests -v tests/*.py
+clean:
+	make -C layers/cpp clean

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,14 @@
 #   python setup.py install
 # You should be able to then use decaf in your python environment.
 
-from distutils.core import setup, Extension
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 from distutils.util import convert_path
 from fnmatch import fnmatchcase
 import os
+import sys
 
 def find_packages(where='.'):
     out = []
@@ -27,10 +31,16 @@ def find_packages(where='.'):
     return out
 
 def run_setup():
+    if sys.version_info < (2, 7):
+        sys.stderr.write("Decaf requires Python >= 2.7\n")
+        exit(-1)
     # Before running setup, let's do a make since we have C shared libraries
     # to be build (note that they are not python extensions...)
     # It's kind of ugly, but let's just keep it this way for simplicity
-    os.system('cd decaf; make; cd ..')
+    retval = os.system('cd decaf; make')
+    if retval != 0:
+        sys.stderr.write("Failed to build the C libraries; exiting.\n")
+        exit(retval)
     setup(name='decaf',
           version='0.9',
           description='Deep convolutional neural network framework',
@@ -42,7 +52,26 @@ def run_setup():
                         'decaf.demos.notebooks': ['*.ipynb'],
                         'decaf.layers.cpp': ['libcpputil.so'],
                        },
-         )
+          install_requires=[
+              'matplotlib',
+              'networkx',
+              'numexpr',
+              'numpy',
+              'pydot',
+              'scipy',
+              'scikit-image',
+          ],
+          extras_require={
+              'benchmarks': ['theano'],
+              'mpi': ['mpi4py'],
+              'demo': [
+                  'python-gflags',
+                  'flask',
+                  'tornado',
+                  'PIL',
+              ],
+          }
+    )
 
 if __name__ == '__main__':
     run_setup()


### PR DESCRIPTION
This commit adds dependencies to setup.py, which should make it easier to install Decaf using pip or easy_install.

For example, you can now run `pip install -e ".[demo]"` to perform an editable local install that includes the extra dependencies for running the demo site.

To discover the dependencies, I used [snakefood](http://furius.ca/snakefood/) to find [all imports](https://gist.github.com/JoshRosen/7668400)

```
sfood-imports ./decaf | cut -d' ' -f2 | sort -u
```

I also made a few minor changes to improve error messages if the C extensions couldn't be built or if the Python version is older than 2.7.
