### PR TITLE
fix random seed generation for single thread

### DIFF
--- a/decaf/util/mpi.py
+++ b/decaf/util/mpi.py
@@ -34,7 +34,7 @@ _MPI_BUFFER_LIMIT = 2 ** 30
 
 # we need to set the random seed different for each mpi instance
 logging.info('blop.util.mpi: seting different random seeds for each node.')
-random.seed(time.time() * RANK)
+random.seed(time.time() * (RANK+1))
 
 def is_dummy():
     '''Returns True if this is a dummy version of MPI.'''


### PR DESCRIPTION
When there is only one thread, RANK=0 and the random seed is always constant. RANK+1 fixes this for the one thread case.
